### PR TITLE
Fix in autotune_scvi.ipynb

### DIFF
--- a/.github/workflows/run_notebook_all.yaml
+++ b/.github/workflows/run_notebook_all.yaml
@@ -17,14 +17,20 @@ jobs:
           - atac/PoissonVI.ipynb
           - atac/scbasset_batch.ipynb
           - atac/scbasset.ipynb
+          - custom_dl/ann_collection.ipynb
+          - custom_dl/lamin.ipynb
+          - custom_dl/Tahoe100_mrVI_lamin.ipynb
+          - custom_dl/tiledb.ipynb
+          - cytometry/CytoVI_advanced_tutorial.ipynb
+          - cytometry/CytoVI_batch_correction_tutorial.ipynb
           - dev/data_tutorial.ipynb
           - dev/model_user_guide.ipynb
           - dev/module_user_guide.ipynb
-          - hub/Tahoe100.ipynb
           - hub/cellxgene_census_model.ipynb
           - hub/query_hlca_knn.ipynb
           - hub/scvi_hub_intro_and_download.ipynb
           - hub/scvi_hub_upload_and_large_files.ipynb
+          - hub/Tahoe100.ipynb
           - multimodal/cite_scrna_integration_w_totalVI.ipynb
           - multimodal/MultiVI_tutorial.ipynb
           - multimodal/scarches_scvi_tools.ipynb
@@ -37,29 +43,29 @@ jobs:
           - scrna/AutoZI_tutorial.ipynb
           - scrna/cellassign_tutorial.ipynb
           - scrna/contrastiveVI_tutorial.ipynb
+          - scrna/decipher_tutorial.ipynb
           - scrna/harmonization.ipynb
           - scrna/linear_decoder.ipynb
+          - scrna/MrVI_tutorial.ipynb
           - scrna/scanvi_fix.ipynb
           - scrna/scVI_DE_worm.ipynb
           - scrna/seed_labeling.ipynb
-          - scrna/tabula_muris.ipynb
-          - scrna/MrVI_tutorial.ipynb
-          - scrna/decipher_tutorial.ipynb
           - scrna/sysVI.ipynb
+          - scrna/tabula_muris.ipynb
+          - scrna/Tahoe100_mrVI.ipynb
           - scrna/velovi.ipynb
           - spatial/cell2location_lymph_node_spatial_tutorial.ipynb
           - spatial/DestVI_tutorial.ipynb
           - spatial/gimvi_tutorial.ipynb
-          - spatial/stereoscope_heart_LV_tutorial.ipynb
-          - spatial/tangram_scvi_tools.ipynb
           - spatial/resolVI_tutorial.ipynb
           - spatial/scVIVA_tutorial.ipynb
+          - spatial/stereoscope_heart_LV_tutorial.ipynb
+          - spatial/tangram_scvi_tools.ipynb
           - use_cases/autotune_scvi.ipynb
           - use_cases/interpretability.ipynb
           - use_cases/minification.ipynb
           - use_cases/multiGPU.ipynb
-          - use_cases/custom_dl/lamin.ipynb
-          - use_cases/custom_dl/tiledb.ipynb
+          - use_cases/preprocessing.ipynb
 
     uses: ./.github/workflows/run_notebook.yaml
     with:

--- a/.github/workflows/run_notebook_individual.yaml
+++ b/.github/workflows/run_notebook_individual.yaml
@@ -12,14 +12,20 @@ on:
           - atac/PoissonVI.ipynb
           - atac/scbasset_batch.ipynb
           - atac/scbasset.ipynb
+          - custom_dl/ann_collection.ipynb
+          - custom_dl/lamin.ipynb
+          - custom_dl/Tahoe100_mrVI_lamin.ipynb
+          - custom_dl/tiledb.ipynb
+          - cytometry/CytoVI_advanced_tutorial.ipynb
+          - cytometry/CytoVI_batch_correction_tutorial.ipynb
           - dev/data_tutorial.ipynb
           - dev/model_user_guide.ipynb
           - dev/module_user_guide.ipynb
-          - hub/Tahoe100.ipynb
           - hub/cellxgene_census_model.ipynb
           - hub/query_hlca_knn.ipynb
           - hub/scvi_hub_intro_and_download.ipynb
           - hub/scvi_hub_upload_and_large_files.ipynb
+          - hub/Tahoe100.ipynb
           - multimodal/cite_scrna_integration_w_totalVI.ipynb
           - multimodal/MultiVI_tutorial.ipynb
           - multimodal/scarches_scvi_tools.ipynb
@@ -32,29 +38,29 @@ on:
           - scrna/AutoZI_tutorial.ipynb
           - scrna/cellassign_tutorial.ipynb
           - scrna/contrastiveVI_tutorial.ipynb
+          - scrna/decipher_tutorial.ipynb
           - scrna/harmonization.ipynb
           - scrna/linear_decoder.ipynb
+          - scrna/MrVI_tutorial.ipynb
           - scrna/scanvi_fix.ipynb
           - scrna/scVI_DE_worm.ipynb
           - scrna/seed_labeling.ipynb
-          - scrna/tabula_muris.ipynb
-          - scrna/MrVI_tutorial.ipynb
-          - scrna/decipher_tutorial.ipynb
           - scrna/sysVI.ipynb
+          - scrna/tabula_muris.ipynb
+          - scrna/Tahoe100_mrVI.ipynb
           - scrna/velovi.ipynb
           - spatial/cell2location_lymph_node_spatial_tutorial.ipynb
           - spatial/DestVI_tutorial.ipynb
           - spatial/gimvi_tutorial.ipynb
-          - spatial/stereoscope_heart_LV_tutorial.ipynb
-          - spatial/tangram_scvi_tools.ipynb
           - spatial/resolVI_tutorial.ipynb
           - spatial/scVIVA_tutorial.ipynb
+          - spatial/stereoscope_heart_LV_tutorial.ipynb
+          - spatial/tangram_scvi_tools.ipynb
           - use_cases/autotune_scvi.ipynb
           - use_cases/interpretability.ipynb
           - use_cases/minification.ipynb
           - use_cases/multiGPU.ipynb
-          - use_cases/custom_dl/lamin.ipynb
-          - use_cases/custom_dl/tiledb.ipynb
+          - use_cases/preprocessing.ipynb
 
       version:
         description: "latest/stable/semver/branch"

--- a/.github/workflows/run_notebook_individual_macos.yaml
+++ b/.github/workflows/run_notebook_individual_macos.yaml
@@ -12,14 +12,20 @@ on:
           - atac/PoissonVI.ipynb
           - atac/scbasset_batch.ipynb
           - atac/scbasset.ipynb
+          - custom_dl/ann_collection.ipynb
+          - custom_dl/lamin.ipynb
+          - custom_dl/Tahoe100_mrVI_lamin.ipynb
+          - custom_dl/tiledb.ipynb
+          - cytometry/CytoVI_advanced_tutorial.ipynb
+          - cytometry/CytoVI_batch_correction_tutorial.ipynb
           - dev/data_tutorial.ipynb
           - dev/model_user_guide.ipynb
           - dev/module_user_guide.ipynb
-          - hub/Tahoe100.ipynb
           - hub/cellxgene_census_model.ipynb
           - hub/query_hlca_knn.ipynb
           - hub/scvi_hub_intro_and_download.ipynb
           - hub/scvi_hub_upload_and_large_files.ipynb
+          - hub/Tahoe100.ipynb
           - multimodal/cite_scrna_integration_w_totalVI.ipynb
           - multimodal/MultiVI_tutorial.ipynb
           - multimodal/scarches_scvi_tools.ipynb
@@ -32,29 +38,29 @@ on:
           - scrna/AutoZI_tutorial.ipynb
           - scrna/cellassign_tutorial.ipynb
           - scrna/contrastiveVI_tutorial.ipynb
+          - scrna/decipher_tutorial.ipynb
           - scrna/harmonization.ipynb
           - scrna/linear_decoder.ipynb
+          - scrna/MrVI_tutorial.ipynb
           - scrna/scanvi_fix.ipynb
           - scrna/scVI_DE_worm.ipynb
           - scrna/seed_labeling.ipynb
-          - scrna/tabula_muris.ipynb
-          - scrna/MrVI_tutorial.ipynb
-          - scrna/decipher_tutorial.ipynb
           - scrna/sysVI.ipynb
+          - scrna/tabula_muris.ipynb
+          - scrna/Tahoe100_mrVI.ipynb
           - scrna/velovi.ipynb
           - spatial/cell2location_lymph_node_spatial_tutorial.ipynb
           - spatial/DestVI_tutorial.ipynb
           - spatial/gimvi_tutorial.ipynb
-          - spatial/stereoscope_heart_LV_tutorial.ipynb
-          - spatial/tangram_scvi_tools.ipynb
           - spatial/resolVI_tutorial.ipynb
           - spatial/scVIVA_tutorial.ipynb
+          - spatial/stereoscope_heart_LV_tutorial.ipynb
+          - spatial/tangram_scvi_tools.ipynb
           - use_cases/autotune_scvi.ipynb
           - use_cases/interpretability.ipynb
           - use_cases/minification.ipynb
           - use_cases/multiGPU.ipynb
-          - use_cases/custom_dl/lamin.ipynb
-          - use_cases/custom_dl/tiledb.ipynb
+          - use_cases/preprocessing.ipynb
 
       version:
         description: "latest/stable/semver/branch"

--- a/use_cases/autotune_scvi.ipynb
+++ b/use_cases/autotune_scvi.ipynb
@@ -501,6 +501,7 @@
     "    search_space=search_space,\n",
     "    num_samples=5,\n",
     "    resources={\"cpu\": 10, \"gpu\": 1},\n",
+    "    ignore_reinit_error=True,\n",
     ")"
    ]
   },
@@ -960,7 +961,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.7"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
## Formatting

- [ ] My tutorial has only one top-level (`#`) header

## Reproducibility

- [ ] My tutorial works on Google Colab
- [ ] My tutorial sets `scvi.settings.seed = 0` at the beginning of the notebook
- [ ] My tutorial has been run and includes outputs (e.g. plots, tables)

## Other

- [ ] Counts and normalized data should co-exist in the datasets, see the [API overview](https://docs.scvi-tools.org/en/stable/tutorials/notebooks/api_overview.html) for an example
- [ ] For scRNA-seq data, normalization should be counts per median library size and then log1p transformed -- if not, a reason should be given
