### PR TITLE
Add DRVI general pipeline notebook

### DIFF
--- a/.github/workflows/run_linux_cuda.yml
+++ b/.github/workflows/run_linux_cuda.yml
@@ -43,6 +43,7 @@ on:
           - scrna/cellassign_tutorial.ipynb
           - scrna/contrastiveVI_tutorial.ipynb
           - scrna/decipher_tutorial.ipynb
+          - scrna/DRVI_pipeline.ipynb
           - scrna/harmonization.ipynb
           - scrna/JointEmbeddingSCVI_tutorial.ipynb
           - scrna/linear_decoder.ipynb

--- a/.github/workflows/run_notebook_all.yaml
+++ b/.github/workflows/run_notebook_all.yaml
@@ -48,6 +48,7 @@ jobs:
           - scrna/cellassign_tutorial.ipynb
           - scrna/contrastiveVI_tutorial.ipynb
           - scrna/decipher_tutorial.ipynb
+          - scrna/DRVI_pipeline.ipynb
           - scrna/harmonization.ipynb
           - scrna/JointEmbeddingSCVI_tutorial.ipynb
           - scrna/linear_decoder.ipynb

--- a/.github/workflows/run_notebook_individual.yaml
+++ b/.github/workflows/run_notebook_individual.yaml
@@ -43,6 +43,7 @@ on:
           - scrna/cellassign_tutorial.ipynb
           - scrna/contrastiveVI_tutorial.ipynb
           - scrna/decipher_tutorial.ipynb
+          - scrna/DRVI_pipeline.ipynb
           - scrna/harmonization.ipynb
           - scrna/JointEmbeddingSCVI_tutorial.ipynb
           - scrna/linear_decoder.ipynb

--- a/.github/workflows/run_notebook_individual_macos.yaml
+++ b/.github/workflows/run_notebook_individual_macos.yaml
@@ -43,6 +43,7 @@ on:
           - scrna/cellassign_tutorial.ipynb
           - scrna/contrastiveVI_tutorial.ipynb
           - scrna/decipher_tutorial.ipynb
+          - scrna/DRVI_pipeline.ipynb
           - scrna/harmonization.ipynb
           - scrna/JointEmbeddingSCVI_tutorial.ipynb
           - scrna/linear_decoder.ipynb


### PR DESCRIPTION
## Formatting

- [x] My tutorial has only one top-level (`#`) header

## Reproducibility

- [ ] My tutorial works on Google Colab
- [x] My tutorial sets `scvi.settings.seed = 0` at the beginning of the notebook
- [x] My tutorial has been run and includes outputs (e.g. plots, tables)

## Other

- [ ] Counts and normalized data should co-exist in the datasets, see the [API overview](https://docs.scvi-tools.org/en/stable/tutorials/notebooks/api_overview.html) for an example
- [x] For scRNA-seq data, normalization should be counts per median library size and then log1p transformed -- if not, a reason should be given
