### PR TITLE
Fix typo in LDVAE tutorial

### DIFF
--- a/scrna/linear_decoder.ipynb
+++ b/scrna/linear_decoder.ipynb
@@ -447,7 +447,7 @@
    "source": [
     "The question now is how does the latent dimensions link to genes?\n",
     "\n",
-    "For a given cell x, the expression of the gene g is proportional to x_g = w\\_(1, g) * z_1 + ... + w\\_(10, g) * z_10. Moving from low values to high values in z_1 will mostly affect expression of genes with large w\\_(1, :) weights. We can extract these weights from the `LDVAE` model, and identify which genes have high weights for each latent dimension."
+    "For a given cell x, the expression of the gene g is proportional to x_g = w\\_(0, g) * z_0 + ... + w\\_(9, g) * z_9. Moving from low values to high values in z_1 will mostly affect expression of genes with large w\\_(1, :) weights. We can extract these weights from the `LDVAE` model, and identify which genes have high weights for each latent dimension."
    ]
   },
   {


### PR DESCRIPTION
Loadings explanation fix, now for a given cell x, the expression of the gene g correctly starts at dimension 0 instead of 1: 

- before:  x_g = w\_(1, g) * z_1 + ..
- after typo fix: x_g = w\_(0, g) * z_0 + ..