### PR TITLE
docs: fix the Sphinx warnings these notebooks raise in scvi-tools

### DIFF
--- a/custom_dl/api_overview_annbatch.ipynb
+++ b/custom_dl/api_overview_annbatch.ipynb
@@ -17,7 +17,7 @@
     "In addition we will show the usage of [rapids-singlecell](https://rapids-singlecell.readthedocs.io/en/latest/) in Umaps calcualtion. rapids-singlecell provides GPU-accelerated single-cell analysis with an AnnData-first API. It is largely compatible with Scanpy. Computations use CuPy and NVIDIA RAPIDS for performance on large datasets.\n",
     "In order to use rapids-singlecell with scvi-tools, one should install it with \"scvi-tools[rapids]\".\n",
     "\n",
-    "Both of those additions improve the runtime of this tutorial comparing to the original [api_tutorial](quick_start/api_overview.ipynb)\n",
+    "Both of those additions improve the runtime of this tutorial comparing to the original [api_tutorial](../quick_start/api_overview.ipynb)\n",
     "\n",
     "While we focus on scVI in this tutorial, the API is consistent across all models."
    ]

--- a/custom_dl/lamin.ipynb
+++ b/custom_dl/lamin.ipynb
@@ -173,7 +173,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Preprocessing of the data\n",
+    "## Preprocessing of the data\n",
     "\n",
     "In this case we read 2 PBMC data so that we will later show the integration power.\n",
     "We will select the intersection of those 2 datasets gene names, and consolidate cell types names so that they will be alligned"

--- a/hub/cellxgene_census_model.ipynb
+++ b/hub/cellxgene_census_model.ipynb
@@ -524,7 +524,7 @@
     "id": "9M4TTTFoHOkX"
    },
    "source": [
-    "### Setup minified model\n",
+    "## Setup minified model\n",
     "\n",
     "Census was trained on all primary cells. We don't encode covariates so inference and generating latent codes works without retraining on these batches. We have to subset to all training batches.\n",
     "The setup will be optimized in a future version of scvi-tools."
@@ -1846,7 +1846,7 @@
     "id": "56oNDvHNj4uq"
    },
    "source": [
-    "#### Performing differential expression"
+    "### Performing differential expression"
    ]
   },
   {

--- a/hub/scvi_hub_intro_and_download.ipynb
+++ b/hub/scvi_hub_intro_and_download.ipynb
@@ -172,7 +172,7 @@
    "source": [
     "## Overview\n",
     "\n",
-    "**TL;DR**: Hugging Face is a Cloud-based platform that's ideal for storage and sharing of pre-trained ML models. We provide an interface to it in scvi-tools and store pre-trained scvi-tools models on the Hugging Face Model Hub. Read on for more details or jump [here](#Download-models) for practical examples."
+    "**TL;DR**: Hugging Face is a Cloud-based platform that's ideal for storage and sharing of pre-trained ML models. We provide an interface to it in scvi-tools and store pre-trained scvi-tools models on the Hugging Face Model Hub. Read on for more details or jump [here](#download-models) for practical examples."
    ]
   },
   {

--- a/multimodal/scarches_scvi_tools.ipynb
+++ b/multimodal/scarches_scvi_tools.ipynb
@@ -24,7 +24,7 @@
     "id": "bK6B_-AuBwoo"
    },
    "source": [
-    "### Imports and scvi-tools installation (colab)"
+    "## Imports and scvi-tools installation (colab)"
    ]
   },
   {

--- a/r/api_overview_in_R.ipynb
+++ b/r/api_overview_in_R.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Introduction to scvi-tools in R\n",
     "\n",
-    "In this introductory tutorial, we go through the different steps of an scvi-tools workflow. It is the R version of [this](\"https://docs.scvi-tools.org/en/latest/tutorials/notebooks/quick_start/api_overview.html\") python tutorial.\n",
+    "In this introductory tutorial, we go through the different steps of an scvi-tools workflow. It is the R version of [this](https://docs.scvi-tools.org/en/latest/tutorials/notebooks/quick_start/api_overview.html) python tutorial.\n",
     "\n",
     "While we focus on scVI in this tutorial, the API is consistent across all models. "
    ]
@@ -48,7 +48,7 @@
    "id": "8b8faf23-a986-4454-9825-180da23909d3",
    "metadata": {},
    "source": [
-    "### Import Python libraries with reticulate"
+    "## Import Python libraries with reticulate"
    ]
   },
   {
@@ -258,7 +258,7 @@
    "id": "8e5e29c0-62d1-4378-afa4-f753261f2a28",
    "metadata": {},
    "source": [
-    "### Creating and training a model"
+    "## Creating and training a model"
    ]
   },
   {
@@ -357,7 +357,7 @@
    "id": "7b893dba-a219-4568-8a4a-b65cb9467003",
    "metadata": {},
    "source": [
-    "### Show trainning curves"
+    "## Show trainning curves"
    ]
   },
   {
@@ -476,7 +476,7 @@
    "id": "5978b6bd-9aac-43db-9987-c638324454b3",
    "metadata": {},
    "source": [
-    "### Saving and loading"
+    "## Saving and loading"
    ]
   },
   {
@@ -516,7 +516,7 @@
    "id": "8eb59f13-024a-43f9-92d9-b6aeb575a006",
    "metadata": {},
    "source": [
-    "### Obtaining model outputs"
+    "## Obtaining model outputs"
    ]
   },
   {
@@ -661,7 +661,7 @@
    "id": "f40a33e3-01c6-4c09-a9b5-b5a382dfce57",
    "metadata": {},
    "source": [
-    "### Visualization without batch correction"
+    "## Visualization without batch correction"
    ]
   },
   {
@@ -812,7 +812,7 @@
    "id": "7a166da8-6849-4d3e-8e75-f0242e39d3af",
    "metadata": {},
    "source": [
-    "### Visualization with batch correction (scVI)"
+    "## Visualization with batch correction (scVI)"
    ]
   },
   {
@@ -932,7 +932,7 @@
    "id": "184b58fd-1909-4dce-8c14-42d048dd62a1",
    "metadata": {},
    "source": [
-    "### Clustering on the scVI latent space"
+    "## Clustering on the scVI latent space"
    ]
   },
   {
@@ -1002,7 +1002,7 @@
    "id": "5bbabcce-95b8-46a1-b707-7d8e8775801a",
    "metadata": {},
    "source": [
-    "### Differential expression"
+    "## Differential expression"
    ]
   },
   {
@@ -1234,7 +1234,7 @@
    "id": "8f3e3799-0571-42b2-b68b-263f4c9432e8",
    "metadata": {},
    "source": [
-    "### Session Info Summary"
+    "## Session Info Summary"
    ]
   },
   {

--- a/r/python_in_R.ipynb
+++ b/r/python_in_R.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Import Libraries"
+    "## Import Libraries"
    ]
   },
   {
@@ -760,6 +760,9 @@
    "name": "R",
    "pygments_lexer": "r",
    "version": "4.3.3"
+  },
+  "mystnb": {
+   "render_error_lexer": "none"
   }
  },
  "nbformat": 4,

--- a/r/scvi_in_R.ipynb
+++ b/r/scvi_in_R.ipynb
@@ -609,7 +609,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Session Info Summary"
+    "## Session Info Summary"
    ]
   },
   {

--- a/scbs/MethylVI_batch.ipynb
+++ b/scbs/MethylVI_batch.ipynb
@@ -9,7 +9,6 @@
    "source": [
     "# Integrating single-cell methylation data from different scBS-seq experiments with methylVI\n",
     "\n",
-    "---\n",
     "\n",
     "A common problem when analyzing single-cell omics datasets across multiple experiments is the presence of batch effects (i.e., systematic variations due to differences in sequencing platform). Here we demonstrate how methylVI can be used to integrate data from different single-cell bisulfite sequencing platforms. As an example, we'll consider single-cell methylomes from the dentate gyrus region of the brain collected in [\"DNA methylation atlas of the mouse brain at single-cell resolution\"](https://www.nature.com/articles/s41586-020-03182-8) (Liu et al., Nature, 2021) using two sequencing protocols: snmC-seq2 and snm-3C-seq.\n",
     "\n",

--- a/scrna/harmonization.ipynb
+++ b/scrna/harmonization.ipynb
@@ -155,7 +155,7 @@
     "id": "QW3WiY6cQnFr"
    },
    "source": [
-    "### Dataset Preprocessing\n",
+    "## Dataset Preprocessing\n",
     "For this tutorial we use an already preprocessed dataset from the lung atlas integration task in the [scIB manuscript](https://www.biorxiv.org/content/10.1101/2020.05.22.111161v2). To see the exact preprocessing that was done, or to preprocess your own scRNA dataset for use with scvi-tools models, see our [preprocessing tutorial](https://docs.scvi-tools.org/en/stable/tutorials/notebooks/use_cases/preprocessing.html#scrna-seq)."
    ]
   },

--- a/scrna/scVI_DE_worm.ipynb
+++ b/scrna/scVI_DE_worm.ipynb
@@ -204,7 +204,7 @@
     "id": "9M4TTTFoHOkX"
    },
    "source": [
-    "### Take a look at the gene descriptions\n",
+    "## Take a look at the gene descriptions\n",
     "\n",
     "The gene descriptions were taken using the [WormBase API](https://wormbase.org/about/userguide/for_developers#3--10)."
    ]
@@ -297,7 +297,7 @@
     "id": "u9K0Cyl-HOke"
    },
    "source": [
-    "### Selecting genes and loading data\n",
+    "## Selecting genes and loading data\n",
     "\n",
     "We use the utility `scvi.data.poisson_gene_selection` to select genes according to their dropout rate, which is a simple and scalable approach to select genes.\n",
     "\n",
@@ -563,7 +563,7 @@
     "id": "SC6C1aquHOkk"
    },
    "source": [
-    "### Define and train the model"
+    "## Define and train the model"
    ]
   },
   {
@@ -664,7 +664,7 @@
     "id": "lsJzdOyvHOk6"
    },
    "source": [
-    "### Get the latent space and compute UMAP"
+    "## Get the latent space and compute UMAP"
    ]
   },
   {

--- a/scrna/tabula_muris.ipynb
+++ b/scrna/tabula_muris.ipynb
@@ -2312,7 +2312,7 @@
     "id": "gKSa0nVPvEdO"
    },
    "source": [
-    "#### scANVI labels"
+    "### scANVI labels"
    ]
   },
   {

--- a/use_cases/interpretability.ipynb
+++ b/use_cases/interpretability.ipynb
@@ -1209,7 +1209,7 @@
    "source": [
     "SHAP (SHapley Additive exPlanations) values are a popular interpretability technique based on cooperative game theory. The core idea is to fairly allocate the \"credit\" for a model's prediction to each feature, by considering all possible combinations of features and their impact on the prediction. SHAP values are additive, meaning the sum of the SHAP values for all features equals the difference between the model’s output and the average prediction. This method works for any model type, providing a consistent way to explain individual predictions, making it highly versatile and widely applicable. Deep SHAP is an extension of the SHAP method designed specifically for deep learning models, such as the ones in SCVI-Tools. For more information see [this](https://www.nature.com/articles/s41592-024-02511-3)\n",
     "\n",
-    "Calcualtion of SHAP for SC data usually takes a lot of time. In SCVI-Tools we are running an approximation of FastSHAP in order to reduce runtime, where we train a shallow surrogate model to imitate the original model prediction and than run the SHAP over the surrogate model. See [this](\"https://arxiv.org/abs/2107.07436\")"
+    "Calcualtion of SHAP for SC data usually takes a lot of time. In SCVI-Tools we are running an approximation of FastSHAP in order to reduce runtime, where we train a shallow surrogate model to imitate the original model prediction and than run the SHAP over the surrogate model. See [this](https://arxiv.org/abs/2107.07436)"
    ]
   },
   {


### PR DESCRIPTION
scvi-tools renders this repository as part of its documentation and is switching to a `-W` Sphinx build in scverse/scvi-tools#3607, where these warnings become errors. This fixes all 33 of them; the changes are cosmetic and do not touch any code cell or output apart from the two noted below.

- **Heading levels** in 11 notebooks skipped a level (H1 → H3, or H2 → H4). Demoted the offending headings so each notebook has a contiguous hierarchy. No headings were removed or renamed.
- **`use_cases/interpretability.ipynb`** and **`r/api_overview_in_R.ipynb`** had a link target wrapped in quotes — `[text]("https://…")` — which markdown does not treat as a URL. Removed the quotes.
- **`hub/scvi_hub_intro_and_download.ipynb`** linked to `#Download-models`; the generated anchor is lowercase, so the link was dead.
- **`custom_dl/api_overview_annbatch.ipynb`** linked to `quick_start/api_overview.ipynb`, which resolves relative to `custom_dl/`. Made it `../quick_start/api_overview.ipynb`.
- **`r/python_in_R.ipynb`** has an intentional error output demonstrating a `reticulate` type mismatch. Its R traceback cannot be parsed by the `ipythontb` lexer, so the notebook now sets `render_error_lexer` in its `mystnb` metadata.
- **`scbs/MethylVI_batch.ipynb`** had a `---` transition directly below its title; docutils rejects a document that begins with one. Removed it.

Verified by building the scvi-tools documentation with `-W` against this branch: it now completes with zero warnings.
